### PR TITLE
allow extra client options

### DIFF
--- a/lib/vagrant/provisioners/chef_client.rb
+++ b/lib/vagrant/provisioners/chef_client.rb
@@ -17,6 +17,7 @@ module Vagrant
         attr_accessor :environment
         attr_accessor :encrypted_data_bag_secret_key_path
         attr_accessor :encrypted_data_bag_secret
+        attr_accessor :client_options
 
         # Provide defaults in such a way that they won't override the instance
         # variable. This is so merging continues to work properly.
@@ -90,7 +91,7 @@ module Vagrant
 
       def run_chef_client
         command_env = config.binary_env ? "#{config.binary_env} " : ""
-        command = "#{command_env}#{chef_binary_path("chef-client")} -c #{config.provisioning_path}/client.rb -j #{config.provisioning_path}/dna.json"
+        command = "#{command_env}#{chef_binary_path("chef-client")} -c #{config.provisioning_path}/client.rb -j #{config.provisioning_path}/dna.json #{config.client_options}"
 
         config.attempts.times do |attempt|
           if attempt == 0

--- a/lib/vagrant/version.rb
+++ b/lib/vagrant/version.rb
@@ -2,5 +2,5 @@ module Vagrant
   # This will always be up to date with the current version of Vagrant,
   # since it is used to generate the gemspec and is also the source of
   # the version for `vagrant -v`
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end


### PR DESCRIPTION
Allows adding extra options that will be passed to the chef-client binary such as below:

```
    trusty.vm.provision :chef_client do |chef|
      ...
      chef.client_options = '--force-formatter --format doc'
    end
```